### PR TITLE
Allow extraction from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 ## Running
 No third party libraries are necessary. Run the following from the command line
-python Landmark.py <OPTIONAL_PARAMS> <FILE_TO_EXTRACT_FROM> <RULES_FILE>
 
-<OPTIONAL_PARAMS>
--f: Flatten the file
+```
+python Landmark.py [OPTIONAL_PARAMS] [FILE_TO_EXTRACT_FROM] RULES_FILE
+
+[OPTIONAL_PARAMS] -f: Flatten the file
+If FILE_TO_EXTRACT_FROM is not given, input will be taken on stdin.
+```
 
 ### Examples
 ```

--- a/src/extraction/Landmark.py
+++ b/src/extraction/Landmark.py
@@ -225,17 +225,23 @@ def main(argv=None):
                 
         except getopt.error, msg:
             raise Usage(msg)
-        
-        #read the page from arg0
-        page_file_str = args[0]
-        with codecs.open(page_file_str, "r", "utf-8") as myfile:
-            page_str = myfile.read().encode('utf-8')
+        if len(args) > 1:
+                #read the page from arg0
+                page_file_str = args[0]
+                with codecs.open(page_file_str, "r", "utf-8") as myfile:
+                    page_str = myfile.read().encode('utf-8')
 
-        #read the rules from arg1
-        json_file_str = args[1]
-        with codecs.open(json_file_str, "r", "utf-8") as myfile:
+                #read the rules from arg1
+                json_file_str = args[1]
+        else:
+	        #read the page from stdin
+	        page_str = sys.stdin.read().encode('utf-8')
+
+		#read the rules from arg0
+		json_file_str = args[0]
+
+	with codecs.open(json_file_str, "r", "utf-8") as myfile:
             json_str = myfile.read().encode('utf-8')
-        
         json_object = json.loads(json_str)
         rules = RuleSet(json_object)
         


### PR DESCRIPTION
Apache Tika can output structured text for a wide variety of file formats. By allowing `Landmark.py` to take input on stdin, Tika's output can be piped in and filtered:
```
java -jar /path/to/tika-app.jar [filename/url] | python extraction/Landmark.py [options] [rules]
```

Let me know what you think! I'd be happy to iterate.